### PR TITLE
Make README more platform independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ These are the Javadoc taglets for course H01P1A, Objectgericht programmeren, at 
 as well as the more specialized `@immutable`, `@representationObject`, `@representationObjects`, `@peerObject`, `@peerObjects`, `@basic`, `@inspects`, `@mutates`, `@mutates_properties`, `@creates`, and `@may_throw`
 tags.
 
+## Example Documentation
+
 For example, suppose you have the following class:
 
 ```java
@@ -116,6 +118,8 @@ public class Interval {
 
 }
 ```
+
+## Usage
 
 You can generate Javadoc for it by downloading the OGP Taglets .jar file from the [Releases](https://github.com/btj/ogptaglets/releases) page, and then:
 

--- a/README.md
+++ b/README.md
@@ -122,10 +122,11 @@ You can generate Javadoc for it by downloading the OGP Taglets .jar file from th
 1. In Eclipse, in the Project menu, choose **Generate Javadoc...**.
 2. On the first page of the Generate Javadoc wizard, select the file containing the Interval class. Then click Next.
 3. On the second page, select referenced archive `jrt-fs.jar`. Then click Next.
-4. On the third page, enter the following extra Javadoc options (replace `/Users/YOUR_USERNAME/Downloads` by the location where you downloaded the OGP Taglets .jar file):
+4. On the third page, enter the following extra Javadoc options (replace `<download_folder>` by the location where you downloaded the OGP Taglets .jar file; depending on your operating system, this is `/Users/<username>/Downloads` on mac, `C:/Users/<username>/Downloads` on windows, `/home/<username>/Downloads` on linux):
     ```
-    -tagletpath /Users/YOUR_USERNAME/Downloads/ogptaglets-0.2.jar -taglet ogptaglets.ImmutableTaglet -taglet ogptaglets.InvariantsTaglet -taglet ogptaglets.RepresentationObjectTaglet -taglet ogptaglets.RepresentationObjectsTaglet -taglet ogptaglets.PeerObjectTaglet -taglet ogptaglets.PeerObjectsTaglet -taglet ogptaglets.BasicTaglet -taglet ogptaglets.PreconditionsTaglet -taglet ogptaglets.InspectsTaglet -taglet ogptaglets.MutatesTaglet -taglet ogptaglets.MutatesPropertiesTaglet -taglet ogptaglets.CreatesTaglet -taglet ogptaglets.ThrowsTaglet -taglet ogptaglets.MayThrowTaglet -taglet ogptaglets.PostconditionsTaglet
+    -tagletpath <download_folder>/ogptaglets-0.2.jar -taglet ogptaglets.ImmutableTaglet -taglet ogptaglets.InvariantsTaglet -taglet ogptaglets.RepresentationObjectTaglet -taglet ogptaglets.RepresentationObjectsTaglet -taglet ogptaglets.PeerObjectTaglet -taglet ogptaglets.PeerObjectsTaglet -taglet ogptaglets.BasicTaglet -taglet ogptaglets.PreconditionsTaglet -taglet ogptaglets.InspectsTaglet -taglet ogptaglets.MutatesTaglet -taglet ogptaglets.MutatesPropertiesTaglet -taglet ogptaglets.CreatesTaglet -taglet ogptaglets.ThrowsTaglet -taglet ogptaglets.MayThrowTaglet -taglet ogptaglets.PostconditionsTaglet
     ```
+   
    Also, check the _Open generated index file in browser_ checkbox.
    Then, click Finish.
 


### PR DESCRIPTION
Recently, a student came to me for advice on how to get this to work.  He hadn't noticed that the
download path had to be altered for their system.  Instead of blaming the student for not reading
carefully enough, I created this pull request, hoping to avoid this mistake in the future.